### PR TITLE
Simplify Maven plugin configuration

### DIFF
--- a/2021-07-NubesGen-Terraform/src/docs/asciidoc/spine.adoc
+++ b/2021-07-NubesGen-Terraform/src/docs/asciidoc/spine.adoc
@@ -558,15 +558,6 @@ In our case it's the `subscriptionId` and the `resourceGroup`:
     <subscriptionId>1234-abcd</subscriptionId>
     <resourceGroup>rg-quarkus-nubesgen-terraform-001</resourceGroup>
     <appName>app-quarkus-nubesgen-terraform-001</appName>
-    <pricingTier>F1</pricingTier>
-    <region>northeurope</region>
-    <appServicePlanName>plan-quarkus-nubesgen-terraform-001</appServicePlanName>
-    <appServicePlanResourceGroup>rg-quarkus-nubesgen-terraform-001</appServicePlanResourceGroup>
-    <runtime>
-      <os>Linux</os>
-      <javaVersion>Java 11</javaVersion>
-      <webContainer>Java SE</webContainer>
-    </runtime>
     <deployment>
       <resources>
         <resource>


### PR DESCRIPTION
If you have created your App Service instance with Terraform, I believe you only need those options, so it's simpler for end-users. You'll need them if you don't use Terraform, so the plugin can then create the correct plan, using Linux, etc.
I didn't test, but I wonder if the resource group and subscription are mandatory.